### PR TITLE
Implement `Turing.Inference.getlogp_external`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,14 +25,11 @@ jobs:
           - ubuntu-latest
           - macOS-latest
           - windows-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SliceSampling"
 uuid = "43f4d3e8-9711-4a8c-bd1b-03ac73a255cf"
-version = "0.7.6"
+version = "0.7.7"
 
 [deps]
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
@@ -21,7 +21,7 @@ Distributions = "0.25"
 LinearAlgebra = "1"
 LogDensityProblems = "2"
 Random = "1"
-Turing = "0.37, 0.38, 0.39"
+Turing = "0.39.5"
 julia = "1.10"
 
 [extras]

--- a/ext/SliceSamplingTuringExt.jl
+++ b/ext/SliceSamplingTuringExt.jl
@@ -39,13 +39,19 @@ function Turing.Inference.getparams(
 )
     return state.transition.params
 end
+
+function Turing.Inference.getlogp_external(
+    ::Turing.DynamicPPL.Model, t::SliceSampling.Transition, state
+)
+    return t.lp
+end
 # end
 
 function SliceSampling.initial_sample(rng::Random.AbstractRNG, ℓ::Turing.LogDensityFunction)
     model  = ℓ.model
     vi     = Turing.DynamicPPL.VarInfo(rng, model, Turing.SampleFromUniform())
     vi_spl = last(Turing.DynamicPPL.evaluate!!(model, rng, vi, Turing.SampleFromUniform()))
-    θ     = vi_spl[:]
+    θ      = vi_spl[:]
 
     init_attempt_count = 1
     while !all(isfinite.(θ))

--- a/ext/SliceSamplingTuringExt.jl
+++ b/ext/SliceSamplingTuringExt.jl
@@ -22,22 +22,15 @@ Turing.Inference.isgibbscomponent(::SliceSampling.Slice) = true
 Turing.Inference.isgibbscomponent(::SliceSampling.SliceSteppingOut) = true
 Turing.Inference.isgibbscomponent(::SliceSampling.SliceDoublingOut) = true
 
-function Turing.Inference.getparams(
-    ::Turing.DynamicPPL.Model, sample::SliceSampling.UnivariateSliceState
-)
+const SliceSamplingStates = Union{
+    SliceSampling.UnivariateSliceState,
+    SliceSampling.GibbsState,
+    SliceSampling.HitAndRunState,
+    SliceSampling.LatentSliceState,
+    SliceSampling.GibbsPolarSliceState,
+}
+function Turing.Inference.getparams(::Turing.DynamicPPL.Model, sample::SliceSamplingStates)
     return sample.transition.params
-end
-
-function Turing.Inference.getparams(
-    ::Turing.DynamicPPL.Model, state::SliceSampling.GibbsState
-)
-    return state.transition.params
-end
-
-function Turing.Inference.getparams(
-    ::Turing.DynamicPPL.Model, state::SliceSampling.HitAndRunState
-)
-    return state.transition.params
 end
 
 function Turing.Inference.getlogp_external(

--- a/test/turing.jl
+++ b/test/turing.jl
@@ -8,7 +8,10 @@
         return nothing
     end
 
-    @model logp_check() = x ~ Normal()
+    @model function logp_check()
+        a ~ Normal()
+        return b ~ Normal()
+    end
 
     n_samples = 1000
     model = demo()
@@ -36,7 +39,11 @@
         chain_logp_check = sample(
             logp_check(), externalsampler(sampler), 100; progress=false
         )
-        @test isapprox(logpdf.(Normal(), chain_logp_check[:x]), chain_logp_check[:logp])
+        @test isapprox(
+            logpdf.(Normal(), chain_logp_check[:a]) .+
+            logpdf.(Normal(), chain_logp_check[:b]),
+            chain_logp_check[:lp],
+        )
     end
 
     @testset "gibbs($sampler)" for sampler in [
@@ -55,8 +62,15 @@
         )
 
         chain_logp_check = sample(
-            logp_check(), Turing.Gibbs(:x => externalsampler(sampler)), 100; progress=false
+            logp_check(),
+            Turing.Gibbs(:a => externalsampler(sampler), :b => externalsampler(sampler)),
+            100;
+            progress=false,
         )
-        @test isapprox(logpdf.(Normal(), chain_logp_check[:x]), chain_logp_check[:logp])
+        @test isapprox(
+            logpdf.(Normal(), chain_logp_check[:a]) .+
+            logpdf.(Normal(), chain_logp_check[:b]),
+            chain_logp_check[:lp],
+        )
     end
 end


### PR DESCRIPTION
Following on from https://github.com/TuringLang/Turing.jl/pull/2616 this removes the need to re-evaluate the model to obtain logp.

Can't be merged yet since that Turing PR needs to be merged and released.